### PR TITLE
Fix memory leaks

### DIFF
--- a/AprilTagTrackers/Connection.cpp
+++ b/AprilTagTrackers/Connection.cpp
@@ -1,9 +1,9 @@
 #include "Connection.h"
 
 
-Connection::Connection(Parameters* params)
+Connection::Connection(std::shared_ptr<Parameters> params)
+    : parameters(params)
 {
-    parameters = params;
 }
 
 void Connection::StartConnection()

--- a/AprilTagTrackers/Connection.cpp
+++ b/AprilTagTrackers/Connection.cpp
@@ -10,17 +10,17 @@ void Connection::StartConnection()
 {
     if (status == WAITING)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Already waiting for a connection"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         return;
     }
     if (status == CONNECTED)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Already connected. Restart connection?"), wxT("Question"),
             wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
-        if (dial->ShowModal() != wxID_YES)
+        if (dial.ShowModal() != wxID_YES)
         {
             return;
         }
@@ -49,9 +49,9 @@ void Connection::Connect()
     ret >> word;
     if (word != "numtrackers")
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Could not connect to SteamVR driver. Make sure SteamVR is running and the apriltagtrackers driver is installed."), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         status = DISCONNECTED;
         return;
     }
@@ -63,9 +63,9 @@ void Connection::Connect()
         ret >> word;
         if (word != "added")
         {
-            wxMessageDialog* dial = new wxMessageDialog(NULL,
+            wxMessageDialog dial(NULL,
                 wxT("Something went wrong. Try again."), wxT("Error"), wxOK | wxICON_ERROR);
-            dial->ShowModal();
+            dial.ShowModal();
             status = DISCONNECTED;
             return;
         }

--- a/AprilTagTrackers/Connection.h
+++ b/AprilTagTrackers/Connection.h
@@ -9,8 +9,8 @@ public:
     const int DISCONNECTED = 0;
     const int WAITING = 1;
     const int CONNECTED = 2;
-    Connection(Parameters*);
-    Parameters* parameters;
+    Connection(std::shared_ptr<Parameters>);
+    std::shared_ptr<Parameters> parameters;
     void StartConnection();
     std::istringstream Send(std::string lpszWrite);
     std::istringstream SendTracker(int id, double a, double b, double c, double qw, double qx, double qy, double qz, double time, double smoothing);

--- a/AprilTagTrackers/GUI.cpp
+++ b/AprilTagTrackers/GUI.cpp
@@ -1,6 +1,6 @@
 #include "GUI.h"
 
-GUI::GUI(const wxString& title, Parameters * params)
+GUI::GUI(const wxString& title, std::shared_ptr<Parameters> params)
     : wxFrame(NULL, wxID_ANY, title, wxDefaultPosition, wxSize(350, 700))
 {
     wxNotebook* nb = new wxNotebook(this, -1, wxPoint(-1, -1),
@@ -84,7 +84,7 @@ CameraPage::CameraPage(wxNotebook* parent,GUI* parentGUI)
     //parentGUI->rotHbox->Show(false);
 }
 
-ParamsPage::ParamsPage(wxNotebook* parent, Parameters* params)
+ParamsPage::ParamsPage(wxNotebook* parent, std::shared_ptr<Parameters> params)
     :wxPanel(parent)
 {
     parameters = params;

--- a/AprilTagTrackers/GUI.cpp
+++ b/AprilTagTrackers/GUI.cpp
@@ -228,7 +228,7 @@ Keep other parameters as default unless you know what you are doing.");
 
 void ParamsPage::ShowHelp(wxCommandEvent& event)
 {
-    wxMessageDialog* dial = new wxMessageDialog(NULL,
+    wxMessageDialog dial(NULL,
         "Short descriptions of main parameters \n\n\
 Check the github for full tutorial and parameter descriptions!\n\n\
 Parameters you have to set before starting:\n\
@@ -247,7 +247,7 @@ Experimental:\n\
 - Use chessboard calibration: Use the old chessboard calibration. It is not recommended, but if you just have a chessboard and cant print a new board yet, you can check this.\n\n\
 Keep other parameters as default unless you know what you are doing.\n\n\
 Press OK to close this window.", wxT("Message"), wxOK);
-    dial->ShowModal();
+    dial.ShowModal();
 }
 
 void ParamsPage::SaveParams(wxCommandEvent& event)
@@ -278,22 +278,22 @@ void ParamsPage::SaveParams(wxCommandEvent& event)
         parameters->Save();
         if (ignoreTracker0Field->GetValue() && std::stoi(trackerNumField->GetValue().ToStdString()) == 2)
         {
-            wxMessageDialog* dial = new wxMessageDialog(NULL,
+            wxMessageDialog dial(NULL,
                 wxT("Number of trackers is 2 and ignore tracker 0 is on. This will result in only 1 tracker spawning in SteamVR. \nIf you wish to use both feet trackers, keep number of trackers at 3. \n\nParameters saved!"), wxT("Warning"), wxOK | wxICON_WARNING);
-            dial->ShowModal();
+            dial.ShowModal();
         }
         else
         {
-            wxMessageDialog* dial = new wxMessageDialog(NULL,
+            wxMessageDialog dial(NULL,
                 wxT("Parameters saved!"), wxT("Info"), wxOK | wxICON_INFORMATION);
-            dial->ShowModal();
+            dial.ShowModal();
         }
     }
     catch (std::exception&)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Please enter appropriate values. Parameters were not saved."), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
     }
 }
 

--- a/AprilTagTrackers/GUI.h
+++ b/AprilTagTrackers/GUI.h
@@ -24,7 +24,7 @@ private:
 class GUI : public wxFrame
 {
 public:
-    GUI(const wxString& title, Parameters* params);
+    GUI(const wxString& title, std::shared_ptr<Parameters> params);
     static const int CAMERA_BUTTON = 1;
     static const int CAMERA_CALIB_BUTTON = 3;
     static const int CAMERA_CHECKBOX = 4;
@@ -57,12 +57,12 @@ public:
 class ParamsPage : public wxPanel
 {
 public:
-    ParamsPage(wxNotebook* parent, Parameters* params);
+    ParamsPage(wxNotebook* parent, std::shared_ptr<Parameters> params);
 
 private:
     const int SAVE_BUTTON = 2;
     const int HELP_BUTTON = 10;
-    Parameters* parameters;
+    std::shared_ptr<Parameters> parameters;
     wxTextCtrl* cameraAddrField;
     wxTextCtrl* camFpsField;
     wxTextCtrl* camWidthField;

--- a/AprilTagTrackers/Helpers.cpp
+++ b/AprilTagTrackers/Helpers.cpp
@@ -330,9 +330,8 @@ Quaternion<double> mRot2Quat(const cv::Mat& m) {
 void ShowMessage(std::string text, bool stopOnOk)
 {
     std::thread th{ [=]() {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
-        text, wxT("Message"), wxOK);
-    dial->ShowModal();
+        wxMessageDialog dial(NULL, text, wxT("Message"), wxOK);
+        dial.ShowModal();
     } };
 
     th.detach();

--- a/AprilTagTrackers/MyApp.cpp
+++ b/AprilTagTrackers/MyApp.cpp
@@ -11,17 +11,21 @@ int MyApp::OnExit()
 {
     tracker->cameraRunning = false;
     tracker->mainThreadRunning = false;
+    tracker.reset();
+    params.reset();
+    conn.reset();
+    gui.reset();
     Sleep(2000);
     return 0;
 }
 
 bool MyApp::OnInit()
 {
-    params = new Parameters();
-    conn = new Connection(params);
-    tracker = new Tracker(params, conn);
+    params = std::make_shared<Parameters>();
+    conn = std::make_shared<Connection>(params);
+    tracker = std::make_shared<Tracker>(params, conn);
 
-    gui = new GUI(wxT("AprilTag Trackers"),params);
+    gui = std::make_shared<GUI>(wxT("AprilTag Trackers"), params);
     gui->Show(true);
 
     gui->posHbox->Show(false);

--- a/AprilTagTrackers/MyApp.h
+++ b/AprilTagTrackers/MyApp.h
@@ -20,8 +20,8 @@ class MyApp : public wxApp
     std::shared_ptr<GUI> gui;
 
 public:
-    virtual int OnExit();
-    virtual bool OnInit();
+    virtual int OnExit() wxOVERRIDE;
+    virtual bool OnInit() wxOVERRIDE;
     void ButtonPressedCamera(wxCommandEvent&);
     void ButtonPressedCameraCalib(wxCommandEvent&);
     void ButtonPressedCameraPreview(wxCommandEvent&);

--- a/AprilTagTrackers/MyApp.h
+++ b/AprilTagTrackers/MyApp.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <wx/wx.h>
 
 class Connection;
@@ -12,10 +14,10 @@ class Tracker;
 
 class MyApp : public wxApp
 {
-    Tracker* tracker;
-    Parameters* params;
-    Connection* conn;
-    GUI* gui;
+    std::shared_ptr<Tracker> tracker;
+    std::shared_ptr<Parameters> params;
+    std::shared_ptr<Connection> conn;
+    std::shared_ptr<GUI> gui;
 
 public:
     virtual int OnExit();

--- a/AprilTagTrackers/Tracker.cpp
+++ b/AprilTagTrackers/Tracker.cpp
@@ -106,11 +106,11 @@ void Tracker::StartCamera(std::string id)
 
     if (!cap.isOpened())
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Could not start camera. Make sure you entered the correct ID or IP of your camera in the params.\n"
             "For USB cameras, it will be a number, usually 0,1,2... try a few until it works.\n"
             "For IP webcam, the address will be in the format http://'ip - here':8080/video"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         return;
     }
 
@@ -133,9 +133,9 @@ void Tracker::CameraLoop()
     int rotateFlag = -1;
     if (!cap.read(img))
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera error"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         cameraRunning = false;
         cap.release();
         return;
@@ -162,9 +162,9 @@ void Tracker::CameraLoop()
     {
         if (!cap.read(img))
         {
-            wxMessageDialog* dial = new wxMessageDialog(NULL,
+            wxMessageDialog dial(NULL,
                 wxT("Camera error"), wxT("Error"), wxOK | wxICON_ERROR);
-            dial->ShowModal();
+            dial.ShowModal();
             cameraRunning = false;
             break;
         }
@@ -196,9 +196,9 @@ void Tracker::StartCameraCalib()
     }
     if (!cameraRunning)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera not running"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
@@ -239,15 +239,14 @@ void Tracker::CalibrateCameraCharuco()
     int i = 0;
 
     std::thread th{ [=]() {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
-        "Camera calibration started! \n\n"
-        "Place the printed Charuco calibration board on a flat surface. The camera will take a picture every second - take pictures of the board from as many diffrent angles and distances as you can. \n\n"
-        "Alternatively, you can use the board shown on a monitor or switch to old chessboard calibration in params, but both will have worse results or might not work at all. \n\n"
-        "Press OK to close this window.", wxT("Message"), wxOK);
-    dial->ShowModal();
+        wxMessageDialog dial(NULL,
+            "Camera calibration started! \n\n"
+            "Place the printed Charuco calibration board on a flat surface. The camera will take a picture every second - take pictures of the board from as many diffrent angles and distances as you can. \n\n"
+            "Alternatively, you can use the board shown on a monitor or switch to old chessboard calibration in params, but both will have worse results or might not work at all. \n\n"
+            "Press OK to close this window.", wxT("Message"), wxOK);
+        dial.ShowModal();
 
-    mainThreadRunning = false;
-
+        mainThreadRunning = false;
     } };
 
     th.detach();
@@ -341,9 +340,9 @@ void Tracker::CalibrateCameraCharuco()
     parameters->Save();
     mainThreadRunning = false;
     cv::destroyAllWindows();
-    wxMessageDialog* dial = new wxMessageDialog(NULL,
+    wxMessageDialog dial(NULL,
         wxT("Calibration complete."), wxT("Info"), wxOK);
-    dial->ShowModal();
+    dial.ShowModal();
 }
 
 void Tracker::CalibrateCamera()
@@ -455,9 +454,9 @@ void Tracker::CalibrateCamera()
     parameters->Save();
     mainThreadRunning = false;
     cv::destroyAllWindows();
-    wxMessageDialog* dial = new wxMessageDialog(NULL,
+    wxMessageDialog dial(NULL,
         wxT("Calibration complete."), wxT("Info"), wxOK);
-    dial->ShowModal();
+    dial.ShowModal();
 }
 
 void Tracker::StartTrackerCalib()
@@ -469,17 +468,17 @@ void Tracker::StartTrackerCalib()
     }
     if (!cameraRunning)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera not running"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
     if (parameters->camMat.empty())
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera not calibrated"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
@@ -491,7 +490,7 @@ void Tracker::StartTrackerCalib()
 
     //make a new thread with message box, and stop main thread when we press OK
     std::thread th{ [=]() {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
         "Tracker calibration started! \n\nBefore calibrating, set the number of trackers and marker size parameters (measure the white square). Make sure the trackers are completely rigid and cannot bend,"
         "neither the markers or at the connections between markers - use images on github for reference. Wear your trackers, then calibrate them by moving them to the camera closer than 30cm \n\n"
         "Green: This marker is calibrated and can be used to calibrate other markers.\n"
@@ -500,7 +499,7 @@ void Tracker::StartTrackerCalib()
         "Red: This marker cannot be calibrated as no green markers are seen. Rotate the tracker until a green marker is seen along this one.\n"
         "Yellow: The marker is being calibrated. Hold it still for a second.\n\n"
         "When all the markers on all trackers are shown as green, press OK to finish calibration.", wxT("Message"), wxOK);
-    dial->ShowModal();
+    dial.ShowModal();
 
     mainThreadRunning = false;
 
@@ -518,33 +517,33 @@ void Tracker::Start()
     }
     if (!cameraRunning)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera not running"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
     if (parameters->camMat.empty())
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera not calibrated"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
     if (!trackersCalibrated)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Trackers not calibrated"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
     if (connection->status != connection->CONNECTED)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Not connected to steamVR"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         //return;
     }
@@ -656,9 +655,9 @@ void Tracker::CalibrateTracker()
             }
             catch (std::exception&)
             {
-                wxMessageDialog* dial = new wxMessageDialog(NULL,
+                wxMessageDialog dial(NULL,
                     wxT("Something went wrong. Try again."), wxT("Error"), wxOK | wxICON_ERROR);
-                dial->ShowModal();
+                dial.ShowModal();
                 cv::destroyWindow("out");
                 apriltag_detector_destroy(td);
                 mainThreadRunning = false;
@@ -919,9 +918,9 @@ void Tracker::MainLoop()
             /*
             std::string teststr = std::to_string(calibRodr[0]) + " " + std::to_string(calibRodr[1]) + " " + std::to_string(calibRodr[2]);
 
-            wxMessageDialog* dial = new wxMessageDialog(NULL,
+            wxMessageDialog dial(NULL,
                 teststr, wxT("Error"), wxOK | wxICON_ERROR);
-            dial->ShowModal();
+            dial.ShowModal();
             */
             wtranslation = getSpaceCalibEuler(calibRot, cv::Vec3d(0, 0, 0), calibPos(0), calibPos(1), calibPos(2));
             //wrotation = rodr2quat(calibRodr[0], calibRodr[1], calibRodr[2]);
@@ -932,7 +931,7 @@ void Tracker::MainLoop()
 
             dial = new wxMessageDialog(NULL,
                 teststr, wxT("Error"), wxOK | wxICON_ERROR);
-            dial->ShowModal();
+            dial.ShowModal();
 
             Sleep(2000);
             */
@@ -995,9 +994,9 @@ void Tracker::MainLoop()
             }
             catch (std::exception&)
             {
-                wxMessageDialog* dial = new wxMessageDialog(NULL,
+                wxMessageDialog dial(NULL,
                     wxT("Something went wrong when estimating tracker pose. Try again! \nIf the problem persists, try to recalibrate camera and trackers."), wxT("Error"), wxOK | wxICON_ERROR);
-                dial->ShowModal();
+                dial.ShowModal();
                 cv::destroyWindow("out");
                 apriltag_detector_destroy(td);
                 mainThreadRunning = false;

--- a/AprilTagTrackers/Tracker.cpp
+++ b/AprilTagTrackers/Tracker.cpp
@@ -69,10 +69,9 @@ void detectMarkersApriltag(cv::Mat frame, std::vector<std::vector<cv::Point2f> >
 
 } // namespace
 
-Tracker::Tracker(Parameters* params, Connection* conn)
+Tracker::Tracker(std::shared_ptr<Parameters> params, std::shared_ptr<Connection> conn)
+    : parameters(params), connection(conn)
 {
-    parameters = params;
-    connection = conn;
     if (!parameters->trackers.empty())
     {
         trackers = parameters->trackers;

--- a/AprilTagTrackers/Tracker.h
+++ b/AprilTagTrackers/Tracker.h
@@ -4,8 +4,9 @@
 #pragma once
 
 #include <iostream>
-#include <vector>
+#include <memory>
 #include <thread>
+#include <vector>
 
 #include <opencv2/aruco.hpp>
 #include <opencv2/core.hpp>
@@ -20,7 +21,7 @@ class Parameters;
 class Tracker
 {
 public:
-    Tracker(Parameters*, Connection*);
+    Tracker(std::shared_ptr<Parameters>, std::shared_ptr<Connection>);
     void StartCamera(std::string);
     void StartCameraCalib();
     void StartTrackerCalib();
@@ -32,7 +33,7 @@ public:
     bool recalibrate = false;
     bool manualRecalibrate = false;
 
-    GUI* gui;
+    std::shared_ptr<GUI> gui;
 
     cv::Mat wtranslation = (cv::Mat_<double>(4, 4) << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
     Quaternion<double> wrotation = Quaternion<double>(1, 0, 0, 0);
@@ -51,8 +52,8 @@ private:
     cv::Mat retImage;
     bool imageReady = false;
 
-    Parameters* parameters;
-    Connection* connection;
+    std::shared_ptr<Parameters> parameters;
+    std::shared_ptr<Connection> connection;
 
     std::thread cameraThread;
     std::thread mainThread;


### PR DESCRIPTION
* All `wxMessageDialog` were heap allocated and never deleted. This PR fixes that by not putting them on the heap in the first place.
* `MyApp` creates `Tracker`, `Parameters`, `Connection` and `GUI` but didn't clean them up. This PR makes the cleanup automatic with `std::shared_ptr` and releases the pointers in `MyApp::OnExit()`.
* Add override specifiers in `MyApp` to safeguard for typos.

`std::shared_ptr` will handle cleanup as long as there are no cycles in the graph of pointers. This is how the classes are pointing to each other curretly:
![image](https://user-images.githubusercontent.com/1162652/109213044-7244e800-77b0-11eb-9b58-c4eebd126ef9.png)

The threads are not visible in this graph. They need to be accounted for because they are essentially keeping raw pointers to `Connect` and `Tracker` and could potentially be accessing them after `Connect` and `Tracker` have been destroyed if the threads have been detached.