### PR TITLE
Fix wx widgets dialogs and warnings

### DIFF
--- a/AprilTagTrackers/Connection.cpp
+++ b/AprilTagTrackers/Connection.cpp
@@ -10,17 +10,17 @@ void Connection::StartConnection()
 {
     if (status == WAITING)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Already waiting for a connection"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         return;
     }
     if (status == CONNECTED)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Already connected. Restart connection?"), wxT("Question"),
             wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
-        if (dial->ShowModal() != wxID_YES)
+        if (dial.ShowModal() != wxID_YES)
         {
             return;
         }
@@ -49,9 +49,9 @@ void Connection::Connect()
     ret >> word;
     if (word != "numtrackers")
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Could not connect to SteamVR driver. Make sure SteamVR is running and the apriltagtrackers driver is installed."), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         status = DISCONNECTED;
         return;
     }
@@ -63,9 +63,9 @@ void Connection::Connect()
         ret >> word;
         if (word != "added")
         {
-            wxMessageDialog* dial = new wxMessageDialog(NULL,
+            wxMessageDialog dial(NULL,
                 wxT("Something went wrong. Try again."), wxT("Error"), wxOK | wxICON_ERROR);
-            dial->ShowModal();
+            dial.ShowModal();
             status = DISCONNECTED;
             return;
         }

--- a/AprilTagTrackers/Connection.h
+++ b/AprilTagTrackers/Connection.h
@@ -1,5 +1,9 @@
 #pragma once
+#pragma warning(push)
+#pragma warning(disable:4996)
 #include <wx/wx.h>
+#pragma warning(pop)
+
 #include "Parameters.h"
 #include <windows.h>
 

--- a/AprilTagTrackers/GUI.cpp
+++ b/AprilTagTrackers/GUI.cpp
@@ -20,7 +20,7 @@ CameraPage::CameraPage(wxNotebook* parent,GUI* parentGUI)
 {
     wxBoxSizer* hbox = new wxBoxSizer(wxVERTICAL);
 
-    wxFlexGridSizer* fgs = new wxFlexGridSizer(7, 2, 20, 20);
+    wxFlexGridSizer* fgs = new wxFlexGridSizer(2, 20, 20);
 
     wxButton* btn1 = new wxButton(this, GUI::CAMERA_BUTTON, "1. Start/Stop camera");
     wxButton* btn2 = new wxButton(this, GUI::CAMERA_CALIB_BUTTON, "2. Calibrate camera");
@@ -90,7 +90,7 @@ ParamsPage::ParamsPage(wxNotebook* parent, Parameters* params)
     parameters = params;
     wxBoxSizer* hbox = new wxBoxSizer(wxVERTICAL);
 
-    wxFlexGridSizer* fgs = new wxFlexGridSizer(15, 2, 10, 10);
+    wxFlexGridSizer* fgs = new wxFlexGridSizer(2, 10, 10);
 
     wxStaticText* cameraAddrText = new wxStaticText(this, -1, wxT("Ip or ID of camera"));
     cameraAddrText->SetToolTip("Will be a number 0-10 for USB cameras and \nhttp://'ip - here':8080/video for IP webcam");

--- a/AprilTagTrackers/GUI.cpp
+++ b/AprilTagTrackers/GUI.cpp
@@ -228,7 +228,7 @@ Keep other parameters as default unless you know what you are doing.");
 
 void ParamsPage::ShowHelp(wxCommandEvent& event)
 {
-    wxMessageDialog* dial = new wxMessageDialog(NULL,
+    wxMessageDialog dial(NULL,
         "Short descriptions of main parameters \n\n\
 Check the github for full tutorial and parameter descriptions!\n\n\
 Parameters you have to set before starting:\n\
@@ -247,7 +247,7 @@ Experimental:\n\
 - Use chessboard calibration: Use the old chessboard calibration. It is not recommended, but if you just have a chessboard and cant print a new board yet, you can check this.\n\n\
 Keep other parameters as default unless you know what you are doing.\n\n\
 Press OK to close this window.", wxT("Message"), wxOK);
-    dial->ShowModal();
+    dial.ShowModal();
 }
 
 void ParamsPage::SaveParams(wxCommandEvent& event)
@@ -278,22 +278,22 @@ void ParamsPage::SaveParams(wxCommandEvent& event)
         parameters->Save();
         if (ignoreTracker0Field->GetValue() && std::stoi(trackerNumField->GetValue().ToStdString()) == 2)
         {
-            wxMessageDialog* dial = new wxMessageDialog(NULL,
+            wxMessageDialog dial(NULL,
                 wxT("Number of trackers is 2 and ignore tracker 0 is on. This will result in only 1 tracker spawning in SteamVR. \nIf you wish to use both feet trackers, keep number of trackers at 3. \n\nParameters saved!"), wxT("Warning"), wxOK | wxICON_WARNING);
-            dial->ShowModal();
+            dial.ShowModal();
         }
         else
         {
-            wxMessageDialog* dial = new wxMessageDialog(NULL,
+            wxMessageDialog dial(NULL,
                 wxT("Parameters saved!"), wxT("Info"), wxOK | wxICON_INFORMATION);
-            dial->ShowModal();
+            dial.ShowModal();
         }
     }
     catch (std::exception&)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Please enter appropriate values. Parameters were not saved."), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
     }
 }
 

--- a/AprilTagTrackers/GUI.h
+++ b/AprilTagTrackers/GUI.h
@@ -1,6 +1,10 @@
 #pragma once
+#pragma warning(push)
+#pragma warning(disable:4996)
 #include <wx/wx.h>
 #include <wx/notebook.h>
+#pragma warning(pop)
+
 #include "Parameters.h"
 
 class ValueInput : public wxPanel

--- a/AprilTagTrackers/Helpers.cpp
+++ b/AprilTagTrackers/Helpers.cpp
@@ -330,9 +330,8 @@ Quaternion<double> mRot2Quat(const cv::Mat& m) {
 void ShowMessage(std::string text, bool stopOnOk)
 {
     std::thread th{ [=]() {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
-        text, wxT("Message"), wxOK);
-    dial->ShowModal();
+        wxMessageDialog dial(NULL, text, wxT("Message"), wxOK);
+        dial.ShowModal();
     } };
 
     th.detach();

--- a/AprilTagTrackers/Helpers.cpp
+++ b/AprilTagTrackers/Helpers.cpp
@@ -326,13 +326,3 @@ Quaternion<double> mRot2Quat(const cv::Mat& m) {
 
     return q;
 }
-
-void ShowMessage(std::string text, bool stopOnOk)
-{
-    std::thread th{ [=]() {
-        wxMessageDialog dial(NULL, text, wxT("Message"), wxOK);
-        dial.ShowModal();
-    } };
-
-    th.detach();
-}

--- a/AprilTagTrackers/Helpers.h
+++ b/AprilTagTrackers/Helpers.h
@@ -6,7 +6,6 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/calib3d/calib3d.hpp>
 #include <wx/wx.h>
-#include <thread>
 
 #include "Quaternion.h"
 
@@ -20,4 +19,3 @@ bool isRotationMatrix(cv::Mat& R);
 cv::Vec3f rotationMatrixToEulerAngles(cv::Mat& R);
 Quaternion<double> mRot2Quat(const cv::Mat& m);
 cv::Mat getSpaceCalibEuler(cv::Vec3d rvec, cv::Vec3d tvec, double xOffset, double yOffset, double zOffset);
-void ShowMessage(std::string text, bool stopOnOk);

--- a/AprilTagTrackers/Helpers.h
+++ b/AprilTagTrackers/Helpers.h
@@ -5,7 +5,11 @@
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/calib3d/calib3d.hpp>
+
+#pragma warning(push)
+#pragma warning(disable:4996)
 #include <wx/wx.h>
+#pragma warning(pop)
 
 #include "Quaternion.h"
 

--- a/AprilTagTrackers/Helpers.h
+++ b/AprilTagTrackers/Helpers.h
@@ -6,11 +6,6 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/calib3d/calib3d.hpp>
 
-#pragma warning(push)
-#pragma warning(disable:4996)
-#include <wx/wx.h>
-#pragma warning(pop)
-
 #include "Quaternion.h"
 
 void drawMarker(cv::Mat, std::vector<cv::Point2f>, cv::Scalar);

--- a/AprilTagTrackers/MyApp.h
+++ b/AprilTagTrackers/MyApp.h
@@ -1,9 +1,9 @@
-﻿// AprilTagTrackers.h : Include file for standard system include files,
-// or project specific include files.
+﻿#pragma once
 
-#pragma once
-
+#pragma warning(push)
+#pragma warning(disable:4996)
 #include <wx/wx.h>
+#pragma warning(pop)
 
 class Connection;
 class GUI;

--- a/AprilTagTrackers/MyApp.h
+++ b/AprilTagTrackers/MyApp.h
@@ -18,8 +18,8 @@ class MyApp : public wxApp
     GUI* gui;
 
 public:
-    virtual int OnExit();
-    virtual bool OnInit();
+    virtual int OnExit() wxOVERRIDE;
+    virtual bool OnInit() wxOVERRIDE;
     void ButtonPressedCamera(wxCommandEvent&);
     void ButtonPressedCameraCalib(wxCommandEvent&);
     void ButtonPressedCameraPreview(wxCommandEvent&);

--- a/AprilTagTrackers/Tracker.cpp
+++ b/AprilTagTrackers/Tracker.cpp
@@ -1,7 +1,11 @@
 ﻿#include <iostream>
 #include <vector>
 
+#pragma warning(push)
+#pragma warning(disable:4996)
 #include <wx/wx.h>
+#pragma warning(pop)
+
 #include <opencv2/core.hpp>
 #include <opencv2/videoio.hpp>
 #include <opencv2/highgui.hpp>

--- a/AprilTagTrackers/Tracker.cpp
+++ b/AprilTagTrackers/Tracker.cpp
@@ -106,11 +106,11 @@ void Tracker::StartCamera(std::string id)
 
     if (!cap.isOpened())
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Could not start camera. Make sure you entered the correct ID or IP of your camera in the params.\n"
             "For USB cameras, it will be a number, usually 0,1,2... try a few until it works.\n"
             "For IP webcam, the address will be in the format http://'ip - here':8080/video"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         return;
     }
 
@@ -133,9 +133,9 @@ void Tracker::CameraLoop()
     int rotateFlag = -1;
     if (!cap.read(img))
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera error"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         cameraRunning = false;
         cap.release();
         return;
@@ -162,9 +162,9 @@ void Tracker::CameraLoop()
     {
         if (!cap.read(img))
         {
-            wxMessageDialog* dial = new wxMessageDialog(NULL,
+            wxMessageDialog dial(NULL,
                 wxT("Camera error"), wxT("Error"), wxOK | wxICON_ERROR);
-            dial->ShowModal();
+            dial.ShowModal();
             cameraRunning = false;
             break;
         }
@@ -196,9 +196,9 @@ void Tracker::StartCameraCalib()
     }
     if (!cameraRunning)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera not running"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
@@ -239,15 +239,14 @@ void Tracker::CalibrateCameraCharuco()
     int i = 0;
 
     std::thread th{ [=]() {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
-        "Camera calibration started! \n\n"
-        "Place the printed Charuco calibration board on a flat surface. The camera will take a picture every second - take pictures of the board from as many diffrent angles and distances as you can. \n\n"
-        "Alternatively, you can use the board shown on a monitor or switch to old chessboard calibration in params, but both will have worse results or might not work at all. \n\n"
-        "Press OK to close this window.", wxT("Message"), wxOK);
-    dial->ShowModal();
+        wxMessageDialog dial(NULL,
+            "Camera calibration started! \n\n"
+            "Place the printed Charuco calibration board on a flat surface. The camera will take a picture every second - take pictures of the board from as many diffrent angles and distances as you can. \n\n"
+            "Alternatively, you can use the board shown on a monitor or switch to old chessboard calibration in params, but both will have worse results or might not work at all. \n\n"
+            "Press OK to close this window.", wxT("Message"), wxOK);
+        dial.ShowModal();
 
-    mainThreadRunning = false;
-
+        mainThreadRunning = false;
     } };
 
     th.detach();
@@ -341,9 +340,9 @@ void Tracker::CalibrateCameraCharuco()
     parameters->Save();
     mainThreadRunning = false;
     cv::destroyAllWindows();
-    wxMessageDialog* dial = new wxMessageDialog(NULL,
+    wxMessageDialog dial(NULL,
         wxT("Calibration complete."), wxT("Info"), wxOK);
-    dial->ShowModal();
+    dial.ShowModal();
 }
 
 void Tracker::CalibrateCamera()
@@ -455,9 +454,9 @@ void Tracker::CalibrateCamera()
     parameters->Save();
     mainThreadRunning = false;
     cv::destroyAllWindows();
-    wxMessageDialog* dial = new wxMessageDialog(NULL,
+    wxMessageDialog dial(NULL,
         wxT("Calibration complete."), wxT("Info"), wxOK);
-    dial->ShowModal();
+    dial.ShowModal();
 }
 
 void Tracker::StartTrackerCalib()
@@ -469,17 +468,17 @@ void Tracker::StartTrackerCalib()
     }
     if (!cameraRunning)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera not running"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
     if (parameters->camMat.empty())
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera not calibrated"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
@@ -491,7 +490,7 @@ void Tracker::StartTrackerCalib()
 
     //make a new thread with message box, and stop main thread when we press OK
     std::thread th{ [=]() {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
         "Tracker calibration started! \n\nBefore calibrating, set the number of trackers and marker size parameters (measure the white square). Make sure the trackers are completely rigid and cannot bend,"
         "neither the markers or at the connections between markers - use images on github for reference. Wear your trackers, then calibrate them by moving them to the camera closer than 30cm \n\n"
         "Green: This marker is calibrated and can be used to calibrate other markers.\n"
@@ -500,7 +499,7 @@ void Tracker::StartTrackerCalib()
         "Red: This marker cannot be calibrated as no green markers are seen. Rotate the tracker until a green marker is seen along this one.\n"
         "Yellow: The marker is being calibrated. Hold it still for a second.\n\n"
         "When all the markers on all trackers are shown as green, press OK to finish calibration.", wxT("Message"), wxOK);
-    dial->ShowModal();
+    dial.ShowModal();
 
     mainThreadRunning = false;
 
@@ -518,33 +517,33 @@ void Tracker::Start()
     }
     if (!cameraRunning)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera not running"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
     if (parameters->camMat.empty())
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Camera not calibrated"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
     if (!trackersCalibrated)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Trackers not calibrated"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         return;
     }
     if (connection->status != connection->CONNECTED)
     {
-        wxMessageDialog* dial = new wxMessageDialog(NULL,
+        wxMessageDialog dial(NULL,
             wxT("Not connected to steamVR"), wxT("Error"), wxOK | wxICON_ERROR);
-        dial->ShowModal();
+        dial.ShowModal();
         mainThreadRunning = false;
         //return;
     }
@@ -656,9 +655,9 @@ void Tracker::CalibrateTracker()
             }
             catch (std::exception&)
             {
-                wxMessageDialog* dial = new wxMessageDialog(NULL,
+                wxMessageDialog dial(NULL,
                     wxT("Something went wrong. Try again."), wxT("Error"), wxOK | wxICON_ERROR);
-                dial->ShowModal();
+                dial.ShowModal();
                 cv::destroyWindow("out");
                 apriltag_detector_destroy(td);
                 mainThreadRunning = false;
@@ -919,9 +918,9 @@ void Tracker::MainLoop()
             /*
             std::string teststr = std::to_string(calibRodr[0]) + " " + std::to_string(calibRodr[1]) + " " + std::to_string(calibRodr[2]);
 
-            wxMessageDialog* dial = new wxMessageDialog(NULL,
+            wxMessageDialog dial(NULL,
                 teststr, wxT("Error"), wxOK | wxICON_ERROR);
-            dial->ShowModal();
+            dial.ShowModal();
             */
             wtranslation = getSpaceCalibEuler(calibRot, cv::Vec3d(0, 0, 0), calibPos(0), calibPos(1), calibPos(2));
             //wrotation = rodr2quat(calibRodr[0], calibRodr[1], calibRodr[2]);
@@ -932,7 +931,7 @@ void Tracker::MainLoop()
 
             dial = new wxMessageDialog(NULL,
                 teststr, wxT("Error"), wxOK | wxICON_ERROR);
-            dial->ShowModal();
+            dial.ShowModal();
 
             Sleep(2000);
             */
@@ -995,9 +994,9 @@ void Tracker::MainLoop()
             }
             catch (std::exception&)
             {
-                wxMessageDialog* dial = new wxMessageDialog(NULL,
+                wxMessageDialog dial(NULL,
                     wxT("Something went wrong when estimating tracker pose. Try again! \nIf the problem persists, try to recalibrate camera and trackers."), wxT("Error"), wxOK | wxICON_ERROR);
-                dial->ShowModal();
+                dial.ShowModal();
                 cv::destroyWindow("out");
                 apriltag_detector_destroy(td);
                 mainThreadRunning = false;


### PR DESCRIPTION
* All `wxMessageDialog` were heap allocated and never deleted. This PR fixes that by not putting them on the heap in the first place.
* Add override specifiers in `MyApp` to safeguard for typos.
* Remove unused helper `ShowMessage`.
* Hide warnings from wxWidgets so that other warnings are easier to see.
* Let `wxFlexGridSizer` keep track of number of rows instead of specifying upfront. The number of rows specified was wrong and triggered an assert in debug mode.
