### PR TITLE
Thread safe camera

### DIFF
--- a/AprilTagTrackers/Tracker.h
+++ b/AprilTagTrackers/Tracker.h
@@ -4,8 +4,9 @@
 #pragma once
 
 #include <iostream>
-#include <vector>
+#include <mutex>
 #include <thread>
+#include <vector>
 
 #include <opencv2/aruco.hpp>
 #include <opencv2/core.hpp>
@@ -39,6 +40,7 @@ public:
 
 private:
     void CameraLoop();
+    void CopyFreshCameraImageTo(cv::Mat& image);
     void CalibrateCamera();
     void CalibrateCameraCharuco();
     void CalibrateTracker();
@@ -48,7 +50,10 @@ private:
 
     cv::VideoCapture cap;
 
-    cv::Mat retImage;
+    // cameraImage and imageReady are protected by cameraImageMutex.
+    // Use CopyFreshCameraImageTo in order to get the latest camera image.
+    std::mutex cameraImageMutex;
+    cv::Mat cameraImage;
     bool imageReady = false;
 
     Parameters* parameters;


### PR DESCRIPTION
Adding a mutex for synchronizing access to the camera image between producer and consumer thread. Next step could be to avoid copying the image data with `copyTo` and instead just hand over the ownership by assignment of `cv::Mat`.