### PR TITLE
Refactor cmake, hopefully crossplatform now, build apriltag simultaneously.

### DIFF
--- a/AprilTagTrackers/CMakeLists.txt
+++ b/AprilTagTrackers/CMakeLists.txt
@@ -3,14 +3,6 @@
 #
 cmake_minimum_required (VERSION 3.8)
 
-if(NOT EXISTS ${APRILTAG_LIB} )
-  message(FATAL_ERROR "Please set the correct apriltags library." )
-endif()
-
-if(NOT EXISTS "${APRILTAG_INCLUDE_DIR}/apriltag.h" )
-  message(FATAL_ERROR "Please set the correct apriltags include directory." )
-endif()
-
 find_package( OpenCV REQUIRED )
 include_directories( ${OpenCV_INCLUDE_DIRS} )
 include_directories( ${APRILTAG_INCLUDE_DIR} )
@@ -24,5 +16,5 @@ add_executable (AprilTagTrackers ${source})
 
 target_link_libraries( AprilTagTrackers ${OPENVR_LIB} )
 target_link_libraries( AprilTagTrackers ${OpenCV_LIBS} )
-target_link_libraries( AprilTagTrackers ${APRILTAG_LIB} )
+target_link_libraries( AprilTagTrackers apriltags )
 target_link_libraries( AprilTagTrackers wx::net wx::core wx::base)

--- a/AprilTagTrackers/CMakeLists.txt
+++ b/AprilTagTrackers/CMakeLists.txt
@@ -25,9 +25,5 @@ if (MSVC)
     set_target_properties(AprilTagTrackers PROPERTIES LINK_FLAGS /SUBSYSTEM:WINDOWS)
 endif()
 
-# fix for creating debug builds with a release build of opencv
-target_compile_definitions(AprilTagTrackers PUBLIC 
-    $<$<CONFIG:Debug>:CV_IGNORE_DEBUG_BUILD_GUARD>)
-
 # Install target to bin folder
 install(TARGETS AprilTagTrackers RUNTIME)

--- a/AprilTagTrackers/CMakeLists.txt
+++ b/AprilTagTrackers/CMakeLists.txt
@@ -1,20 +1,33 @@
 ﻿# CMakeList.txt : CMake project for AprilTagTrackers, include source and define
 # project specific logic here.
 #
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required(VERSION 3.8)
 
-find_package( OpenCV REQUIRED )
-include_directories( ${OpenCV_INCLUDE_DIRS} )
-include_directories( ${APRILTAG_INCLUDE_DIR} )
-include_directories( ${OPENVR_INCLUDE_DIR} )
+# Find prebuilt libraries
+find_package(OpenCV REQUIRED)
+if (NOT ${OpenCV_opencv_aruco_FOUND})
+    message(FATAL_ERROR "Missing Aruco module. Rebuild OpenCV with modules from opencv_contrib")
+endif()
 
 # Add source to this project's executable.
 file(GLOB source "*.cpp" "*.h")
 add_executable (AprilTagTrackers ${source})
 
-# TODO: Add tests and install targets if needed.
+# Link paths to libraries
+target_link_libraries(AprilTagTrackers PUBLIC ${OpenVR_LIBS})
+target_include_directories(AprilTagTrackers PUBLIC ${OpenVR_INCLUDE_DIR})
 
-target_link_libraries( AprilTagTrackers ${OPENVR_LIB} )
-target_link_libraries( AprilTagTrackers ${OpenCV_LIBS} )
-target_link_libraries( AprilTagTrackers apriltags )
-target_link_libraries( AprilTagTrackers wx::net wx::core wx::base)
+# Link libraries defined as targets, includes are automatic
+target_link_libraries(AprilTagTrackers PUBLIC ${OpenCV_LIBS} apriltags wx::net wx::core wx::base)
+
+if (MSVC)
+    # tell the msvc linker this is a windows application
+    set_target_properties(AprilTagTrackers PROPERTIES LINK_FLAGS /SUBSYSTEM:WINDOWS)
+endif()
+
+# fix for creating debug builds with a release build of opencv
+target_compile_definitions(AprilTagTrackers PUBLIC 
+    $<$<CONFIG:Debug>:CV_IGNORE_DEBUG_BUILD_GUARD>)
+
+# Install target to bin folder
+install(TARGETS AprilTagTrackers RUNTIME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,22 +3,25 @@
 #
 cmake_minimum_required (VERSION 3.8)
 
-project ("AprilTagTrackers")
+project("AprilTagTrackers")
 
-#only supported for now
-SET (PLATFORM_NAME "win")
-SET (PROCESSOR_ARCH "64")
+# Force wxWidgets to build as a static library
+set(wxBUILD_SHARED "0")
 
-SET (APRILTAG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/apriltag" CACHE PATH "Directory of apriltag header files." )
-SET (wxBUILD_SHARED "0" CACHE BOOL "")
+# Include subprojects, but exclude them from ALL_BUILD 
+# as they may have extra unnecessary targets
+add_subdirectory("apriltag" EXCLUDE_FROM_ALL)
+add_subdirectory("wxWidgets" EXCLUDE_FROM_ALL)
+add_subdirectory("openvr" EXCLUDE_FROM_ALL)
 
-SET (OPENVR_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/openvr/headers")
-find_library(OPENVR_LIB openvr_api HINTS "${CMAKE_CURRENT_SOURCE_DIR}/openvr/lib/${PLATFORM_NAME}${PROCESSOR_ARCH}/" NO_DEFAULT_PATH )
+# Hacky way to get openvr lib, as the main repo has been broken for months
+# TODO: fork openvr to fix build errors
+get_directory_property(PLATFORM_NAME DIRECTORY "openvr" DEFINITION "PLATFORM_NAME")
+get_directory_property(PROCESSOR_ARCH DIRECTORY "openvr" DEFINITION "PROCESSOR_ARCH")
+set(OpenVR_LIBS "${CMAKE_CURRENT_SOURCE_DIR}/openvr/lib/${PLATFORM_NAME}${PROCESSOR_ARCH}/openvr_api.lib")
+set(OpenVR_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/openvr/headers")
 
-# Include sub-projects.
-add_subdirectory("apriltag")
-add_subdirectory("wxWidgets")
-add_subdirectory("openvr")
-add_subdirectory ("AprilTagTrackers")
+# Include main project
+add_subdirectory("AprilTagTrackers")
+
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT AprilTagTrackers)
-set_target_properties("AprilTagTrackers" PROPERTIES LINK_FLAGS /SUBSYSTEM:WINDOWS )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ project ("AprilTagTrackers")
 SET (PLATFORM_NAME "win")
 SET (PROCESSOR_ARCH "64")
 
-SET (APRILTAG_LIB "${CMAKE_CURRENT_SOURCE_DIR}/apriltag/build/LIBRARY_OUTPUT_DIRECTORY/Release/apriltags.lib" CACHE FILEPATH "Path to apriltags.lib library file." )
 SET (APRILTAG_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/apriltag" CACHE PATH "Directory of apriltag header files." )
 SET (wxBUILD_SHARED "0" CACHE BOOL "")
 
@@ -17,6 +16,7 @@ SET (OPENVR_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/openvr/headers")
 find_library(OPENVR_LIB openvr_api HINTS "${CMAKE_CURRENT_SOURCE_DIR}/openvr/lib/${PLATFORM_NAME}${PROCESSOR_ARCH}/" NO_DEFAULT_PATH )
 
 # Include sub-projects.
+add_subdirectory("apriltag")
 add_subdirectory("wxWidgets")
 add_subdirectory("openvr")
 add_subdirectory ("AprilTagTrackers")


### PR DESCRIPTION
Pretty simple to build apriltag along with the other libs. It is a it odd that the fork of apriltag changes the cmake project name to apriltags. It also apparently does not need the include_directories and the APRILTAG_INCLUDE_DIR variable, as target_link_libraries is able to include those automatically.

I removed the checks for whether the variables were set as they should always be set by the root cmake file as long as the submodule is fetched.