### PR TITLE
Switch from clock() to std::chrono so time works right on Linux

### DIFF
--- a/AprilTagTrackers/Tracker.h
+++ b/AprilTagTrackers/Tracker.h
@@ -5,6 +5,7 @@
 #include <thread>
 #include <vector>
 #include <math.h>
+#include <chrono>
 
 #include <opencv2/aruco.hpp>
 #include <opencv2/core.hpp>
@@ -87,7 +88,7 @@ private:
 
     //Quaternion<double> q;
 
-    clock_t last_frame_time;
+    std::chrono::steady_clock::time_point last_frame_time;
 
     MyApp* parentApp;
 };


### PR DESCRIPTION
I was having some weird timing-related issues on Linux with stuff like the FPS counter and cam preview refresh. It turns out they all use clock() which has a different meaning on Linux and other POSIX platforms than on Windows - it measures the amount of CPU time used by the current process, rather than elapsed wall-clock time like on Windows. Since the CPU was idle a lot of the time, the code thought a lot less time had passed than in reality and stuff broke. Using std::chrono::steady_clock from the C++ standard library seems to fix this and should hopefully work on all current platforms.