### PR TITLE
PreviewWindow destroyWindow hangs

### DIFF
--- a/AprilTagTrackers/GUI.cpp
+++ b/AprilTagTrackers/GUI.cpp
@@ -542,7 +542,10 @@ PreviewWindow::PreviewWindow(std::string _windowName)
 void PreviewWindow::Close()
 {
     if (IsVisible())
+    {
         cv::destroyWindow(windowName);
+        cv::pollKey();
+    }
 }
 
 bool PreviewWindow::IsVisible() const
@@ -556,7 +559,7 @@ bool PreviewWindow::IsVisible() const
 void PreviewWindow::SetWindowName(std::string _windowName)
 {
     // Another call to imshow will recreate it
-    if (IsVisible()) cv::destroyWindow(windowName);
+    Close();
     windowName = std::move(_windowName);
 }
 

--- a/AprilTagTrackers/MyApp.cpp
+++ b/AprilTagTrackers/MyApp.cpp
@@ -76,6 +76,9 @@ void MyApp::ButtonPressedCamera(wxCommandEvent& event)
 void MyApp::ButtonPressedCameraPreview(wxCommandEvent& event)
 {
     tracker->showCameraPreview = event.IsChecked();
+    // Window will be opened by imshow if enabled, only need to close
+    if (!tracker->showCameraPreview)
+        gui->camWindow.Close();
 }
 
 void MyApp::ButtonPressedCameraCalib(wxCommandEvent& event)
@@ -135,6 +138,9 @@ void MyApp::ButtonPressedLockHeight(wxCommandEvent& event)
 void MyApp::ButtonPressedDisableOut(wxCommandEvent& event)
 {
     tracker->showOutPreview = event.IsChecked();
+    // Window will be opened by imshow if enabled, only need to close
+    if (!tracker->showOutPreview)
+        gui->outWindow.Close();
 }
 
 void MyApp::ButtonPressedDisableOpenVrApi(wxCommandEvent& event)
@@ -294,7 +300,7 @@ static void wxWidgetsAssertHandler(const wxString& file, int line, const wxStrin
 static const bool errorHandlersRedirected = ([]()
     {
         cv::redirectError(&OpenCVErrorHandler);
-        cv::utils::logging::setLogLevel(cv::utils::logging::LOG_LEVEL_WARNING);
+        cv::utils::logging::setLogLevel(cv::utils::logging::LOG_LEVEL_VERBOSE);
         wxSetAssertHandler(&wxWidgetsAssertHandler);
         return true; //
     })();


### PR DESCRIPTION
Finally figured out highgui.
destroyWindow needs to be called on the thread that created the window.
imshow creates a window, so either imshow needs to be called from the main thread, or we previously call namedWindow on the main thread and then allow imshow.