### PR TITLE
Fix linux preview flicker and aspect ratio

### DIFF
--- a/AprilTagTrackers/GUI/MainFrame.cpp
+++ b/AprilTagTrackers/GUI/MainFrame.cpp
@@ -152,7 +152,17 @@ void GUI::MainFrame::OnNotebookPageChanged(wxBookCtrlEvent& evt)
 void GUI::MainFrame::SetPreviewVisible(bool visible, PreviewId id, bool userCanDestroy)
 {
     int idx = static_cast<int>(id);
-    previews[idx].SetVisible(visible, userCanDestroy);
+    if (visible)
+    {
+        if (userCanDestroy)
+            previews[idx].Show(PreviewFrame::CloseButton::Show);
+        else
+            previews[idx].Show(PreviewFrame::CloseButton::Hide);
+    }
+    else
+    {
+        previews[idx].Hide();
+    }
 }
 
 void GUI::MainFrame::SaveParams()
@@ -212,7 +222,7 @@ void GUI::MainFrame::CreateCameraPage(RefPtr<wxNotebook> pages)
             }})
         .Add(Button{lc.CAMERA_PREVIEW_CAMERA, [this](auto&)
             {
-                previews[static_cast<int>(PreviewId::Camera)].SetVisible(true);
+                previews[static_cast<int>(PreviewId::Camera)].Show();
             }})
         .Add(Button{lc.CAMERA_CALIBRATE_CAMERA, [this](auto&)
             {

--- a/AprilTagTrackers/GUI/PreviewPane.cpp
+++ b/AprilTagTrackers/GUI/PreviewPane.cpp
@@ -12,7 +12,7 @@
 #include <wx/sizer.h>
 
 PreviewPane::PreviewPane(RefPtr<wxWindow> parent, wxWindowID _id)
-    : wxPanel(parent, _id, wxDefaultPosition, wxSize(360, 640)), id(_id),
+    : wxPanel(parent, _id, wxDefaultPosition, wxSize(640, 480)), id(_id),
       renderLoop(std::make_unique<PreviewRenderLoop>(*this))
 {
     Hide();

--- a/AprilTagTrackers/GUI/PreviewPane.cpp
+++ b/AprilTagTrackers/GUI/PreviewPane.cpp
@@ -42,8 +42,8 @@ void PreviewPane::OnPaintEvent(wxPaintEvent& evt)
 
     // gc->SetInterpolationQuality(wxInterpolationQuality::wxINTERPOLATION_FAST);
     gc->DrawBitmap(bitmap, 0, 0, drawArea.x, drawArea.y);
-
-    evt.Skip();
+    // maybe its clearing the background here?
+    // evt.Skip();
 }
 
 void PreviewPane::UpdateImage(const cv::Mat& newImage)

--- a/AprilTagTrackers/GUI/PreviewPane.cpp
+++ b/AprilTagTrackers/GUI/PreviewPane.cpp
@@ -69,6 +69,7 @@ void PreviewPane::UpdateImage(const cv::Mat& newImage)
                 {
                     item->SetRatio(x, y);
                 }
+                SendSizeEventToParent();
             });
     }
 }

--- a/AprilTagTrackers/GUI/PreviewPane.cpp
+++ b/AprilTagTrackers/GUI/PreviewPane.cpp
@@ -64,7 +64,11 @@ void PreviewPane::UpdateImage(const cv::Mat& newImage)
     {
         CallAfter([this, x = image.cols, y = image.rows]
             {
-                SetMinSize(wxSize(x, y));
+                OptRefPtr<wxSizerItem> item = GetContainingSizer()->GetItem(this);
+                if (item.NotNull())
+                {
+                    item->SetRatio(x, y);
+                }
             });
     }
 }

--- a/AprilTagTrackers/GUI/PreviewPane.h
+++ b/AprilTagTrackers/GUI/PreviewPane.h
@@ -4,6 +4,7 @@
 
 #include <opencv2/core.hpp>
 #include <wx/frame.h>
+#include <wx/graphics.h>
 #include <wx/panel.h>
 #include <wx/sizer.h>
 #include <wx/timer.h>
@@ -38,6 +39,9 @@ private:
     cv::Mat image, swapImage;
     bool newImageReady = false;
     std::mutex imageMutex;
+
+    wxGraphicsBitmap bitmap = wxNullGraphicsBitmap;
+    wxGraphicsBrush backgroundBrush = wxNullGraphicsBrush;
 };
 
 class PreviewRenderLoop : private wxTimer


### PR DESCRIPTION
Now draws the image every paint event even if it hasnt changed.
Default preview size is now 640x480.
The aspect ratio of the preview now updates consitently.