### PR TITLE
Changes to structure of the install directory

### DIFF
--- a/AprilTagTrackers/CMakeLists.txt
+++ b/AprilTagTrackers/CMakeLists.txt
@@ -124,14 +124,14 @@ if(ENABLE_ASAN)
 endif()
 
 # Install application to bin folder
-install(TARGETS AprilTagTrackers RUNTIME)
+install(TARGETS AprilTagTrackers RUNTIME DESTINATION ".")
 
 # Find the resource file and icon
 target_include_directories(AprilTagTrackers PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/resources")
 
 if(WIN32)
     # install pdb file for debugging
-    install(FILES $<TARGET_PDB_FILE:AprilTagTrackers> DESTINATION "bin" OPTIONAL)
+    install(FILES $<TARGET_PDB_FILE:AprilTagTrackers> DESTINATION "." OPTIONAL)
 
     # set as GUI application on windows
     set_target_properties(AprilTagTrackers PROPERTIES WIN32_EXECUTABLE TRUE)

--- a/AprilTagTrackers/Config.h
+++ b/AprilTagTrackers/Config.h
@@ -65,7 +65,7 @@ public:
 class UserConfig : public FS::Serializable<UserConfig>
 {
 public:
-    UserConfig() : FS::Serializable<UserConfig>("config.yaml") {}
+    UserConfig() : FS::Serializable<UserConfig>("config/config.yaml") {}
 
     REFLECTABLE_BEGIN;
     FIELD(SemVer, driver_version) = SemVer::Parse(REFLECTABLE_STRINGIZE(ATT_DRIVER_VERSION));
@@ -143,7 +143,7 @@ public:
 class CalibrationConfig : public FS::Serializable<CalibrationConfig>
 {
 public:
-    CalibrationConfig() : FS::Serializable<CalibrationConfig>("calib.yaml") {}
+    CalibrationConfig() : FS::Serializable<CalibrationConfig>("config/calib.yaml") {}
 
     REFLECTABLE_BEGIN;
     FIELD(cv::Mat, camMat);
@@ -159,7 +159,7 @@ public:
 class ArucoConfig : public FS::Serializable<ArucoConfig>
 {
 public:
-    ArucoConfig() : FS::Serializable<ArucoConfig>("aruco.yaml")
+    ArucoConfig() : FS::Serializable<ArucoConfig>("config/aruco.yaml")
     {
         auto p = cv::aruco::DetectorParameters::create();
         p->detectInvertedMarker = true;

--- a/AprilTagTrackers/Connection.cpp
+++ b/AprilTagTrackers/Connection.cpp
@@ -159,8 +159,7 @@ void Connection::Connect()
     dial2.ShowModal();
 
     */
-    // TODO: Maybe move to bindings/att_actions.json
-    const auto bindingsPath = std::filesystem::absolute("att_actions.json");
+    const auto bindingsPath = std::filesystem::absolute("bindings/att_actions.json");
     if (!std::filesystem::exists(bindingsPath))
     {
         SetError(ErrorCode::BINDINGS_MISSING);

--- a/AprilTagTrackers/Localization.h
+++ b/AprilTagTrackers/Localization.h
@@ -16,7 +16,7 @@
 class Localization : public FS::Serializable<Localization>
 {
 public:
-    static inline const FS::Path localesDir = std::filesystem::absolute("locales");
+    static inline const FS::Path localesDir = std::filesystem::absolute("config/locales");
 
     // Keep synced
     static constexpr std::array<std::string_view, 2> LANG_CODE_MAP{

--- a/AprilTagTrackers/Localization.h
+++ b/AprilTagTrackers/Localization.h
@@ -16,7 +16,7 @@
 class Localization : public FS::Serializable<Localization>
 {
 public:
-    static inline const FS::Path localesDir = std::filesystem::absolute("config/locales");
+    static inline const FS::Path localesDir = std::filesystem::absolute("locales");
 
     // Keep synced
     static constexpr std::array<std::string_view, 2> LANG_CODE_MAP{

--- a/AprilTagTrackers/Serializable.h
+++ b/AprilTagTrackers/Serializable.h
@@ -200,6 +200,11 @@ inline bool Serializable<ST>::Save() const
 {
     ATASSERT("filePath is not empty.", !filePath.empty());
     cv::FileStorage fs{filePath.generic_string(), cv::FileStorage::WRITE};
+    if (!fs.isOpened())
+    {
+        std::filesystem::create_directories(filePath.parent_path());
+        fs.open(filePath.generic_string(), cv::FileStorage::WRITE);
+    }
     if (!fs.isOpened()) return false;
     WriteEach(fs, Reflect::DerivedThis<ST>(*this));
     fs.release();

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,13 +58,9 @@ att_add_project(
     DEPENDS ${ATT_DEPS}
 )
 
+# bindings and locales installed to a subfolder
+install(DIRECTORY "bindings" "locales" DESTINATION ".")
+
 # create empty config directory
-# install(DIRECTORY DESTINATION "config")
-
-# bindings installed to a subfolder
-install(DIRECTORY "bindings" DESTINATION ".")
-
-# locales installed to a subfolder in config
-install(DIRECTORY "locales" DESTINATION "config")
-
+install(DIRECTORY DESTINATION "config")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,4 @@ att_add_project(
 # bindings and locales installed to a subfolder
 install(DIRECTORY "bindings" "locales" DESTINATION ".")
 
-# create empty config directory
-install(DIRECTORY DESTINATION "config")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,13 @@ att_add_project(
     DEPENDS ${ATT_DEPS}
 )
 
-# bindings and locales installed to a subfolder
-install(DIRECTORY "bindings" "locales" DESTINATION ".")
-
 # create empty config directory
-install(DIRECTORY DESTINATION "config")
+# install(DIRECTORY DESTINATION "config")
+
+# bindings installed to a subfolder
+install(DIRECTORY "bindings" DESTINATION ".")
+
+# locales installed to a subfolder in config
+install(DIRECTORY "locales" DESTINATION "config")
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,5 +58,9 @@ att_add_project(
     DEPENDS ${ATT_DEPS}
 )
 
-# bindings installed in place, locales to a subfolder
-install(DIRECTORY "bindings/" "locales" DESTINATION "bin")
+# bindings and locales installed to a subfolder
+install(DIRECTORY "bindings" "locales" DESTINATION ".")
+
+# create empty config directory
+install(DIRECTORY DESTINATION "config")
+


### PR DESCRIPTION
Some modifications to the structure of the install to make it clearer.

- Moved driver files to driver_files subdirectory
- Moved ApriltagTrackers.exe to top level
- Moved bindings and locales to top level
- Moved config and calibration files to a config subfolder