### PR TITLE
Enable gstreamer linux

### DIFF
--- a/AprilTagTrackers/MyApp.cpp
+++ b/AprilTagTrackers/MyApp.cpp
@@ -1,8 +1,8 @@
 #include "MyApp.hpp"
 
-#ifdef ATT_OVERRIDE_ERROR_HANDLERS
 #include <opencv2/core/utils/logger.hpp>
 
+#ifdef ATT_OVERRIDE_ERROR_HANDLERS
 #include <exception>
 #include <stdexcept>
 #endif
@@ -108,9 +108,14 @@ static void wxWidgetsAssertHandler(const wxString& file, int line, const wxStrin
 static const bool errorHandlersRedirected = ([]()
     {
         cv::redirectError(&OpenCVErrorHandler);
-        cv::utils::logging::setLogLevel(cv::utils::logging::LOG_LEVEL_WARNING);
         wxSetAssertHandler(&wxWidgetsAssertHandler);
         return true;
     })();
 
 #endif
+
+static const bool opencvSetLogLevelWarning = ([]()
+    {
+        cv::utils::logging::setLogLevel(cv::utils::logging::LOG_LEVEL_WARNING);
+        return true;
+    })();

--- a/vcpkg-ports/opencv4/portfile.cmake
+++ b/vcpkg-ports/opencv4/portfile.cmake
@@ -79,6 +79,10 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
  "dc1394"    WITH_1394
 )
 
+if (VCPKG_TARGET_IS_LINUX)
+  set(WITH_GSTREAMER ON)
+endif()
+
 # Cannot use vcpkg_check_features() for "dnn", "gtk", ipp", "openmp", "ovis", "python", "qt, "tbb"
 set(BUILD_opencv_dnn OFF)
 if("dnn" IN_LIST FEATURES)
@@ -462,6 +466,7 @@ vcpkg_cmake_configure(
         -DWITH_TBB=${WITH_TBB}
         -DWITH_OPENJPEG=OFF
         -DWITH_CPUFEATURES=OFF
+        -DWITH_GSTREAMER=${WITH_GSTREAMER}
         ###### BUILD_options (mainly modules which require additional libraries)
         -DBUILD_opencv_ovis=${BUILD_opencv_ovis}
         -DBUILD_opencv_dnn=${BUILD_opencv_dnn}


### PR DESCRIPTION
Mainly a vcpkg issue.
The gstreamer port cannot be built on linux yet, its been an open issue for a while.
opencv already has built in mechanisms to find gstreamer, however, the portfile needed to be modified to always enable WITH_GSTREAMER on linux.