### PR TITLE
Build release and debug in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
           path: AprilTagTrackers-Linux.tar
 
       - name: Upload Debug (Linux)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v3
         with:
           name: AprilTagTrackers-Debug-Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       - name: CMake Configure
         run: >
           cmake -B build -G "Ninja Multi-Config"
-          -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake
+          -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake"
 
       - name: CMake Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,14 +67,17 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: CMake Configure
-        run: |
-          cmake -B build/release -G Ninja -DCMAKE_INSTALL_PREFIX="./install/release" \
-          -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake" \
-           -DVCPKG_INSTALLED_DIR="./build/vcpkg_installed"
-          cmake -B build/debug -G Ninja -DCMAKE_INSTALL_PREFIX="./install/release" \
-          -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake" \
-          -DVCPKG_INSTALLED_DIR="./build/vcpkg_installed" \
+      - name: CMake Configure Release
+        run: >
+          cmake -B build/release -G Ninja -DCMAKE_INSTALL_PREFIX="./install/release"
+          -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake"
+          -DVCPKG_INSTALLED_DIR="./build/vcpkg_installed"
+
+      - name: CMake Configure Debug
+        run: >
+          cmake -B build/debug -G Ninja -DCMAKE_INSTALL_PREFIX="./install/release"
+          -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake"
+          -DVCPKG_INSTALLED_DIR="./build/vcpkg_installed"
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: CMake Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,13 +69,17 @@ jobs:
 
       - name: CMake Configure Release
         run: >
-          cmake -B build/release -G Ninja -DCMAKE_INSTALL_PREFIX="./install/release"
+          cmake -B build/release -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_INSTALL_PREFIX="./install/release"
           -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake"
           -DVCPKG_INSTALLED_DIR="./build/vcpkg_installed"
 
       - name: CMake Configure Debug
         run: >
-          cmake -B build/debug -G Ninja -DCMAKE_INSTALL_PREFIX="./install/release"
+          cmake -B build/debug -G Ninja
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_INSTALL_PREFIX="./install/debug"
           -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake"
           -DVCPKG_INSTALLED_DIR="./build/vcpkg_installed"
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,8 @@ jobs:
 
       - name: CMake Configure
         run: >
-          cmake -B build -G Ninja Multi-Config
-          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_CMAKE_TOOLCHAIN }}
+          cmake -B build -G "Ninja Multi-Config"
+          -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake
 
       - name: CMake Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,19 +68,19 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: CMake Configure
-        run: >
-          cmake -B build -G "Ninja Multi-Config"
-          -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake"
+        run: |
+          cmake -B build/release -G Ninja -DCMAKE_INSTALL_PREFIX="./install/release" \
+          -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake" \
+           -DVCPKG_INSTALLED_DIR="./build/vcpkg_installed"
+          cmake -B build/debug -G Ninja -DCMAKE_INSTALL_PREFIX="./install/release" \
+          -DCMAKE_TOOLCHAIN_FILE="./vcpkg/scripts/buildsystems/vcpkg.cmake" \
+          -DVCPKG_INSTALLED_DIR="./build/vcpkg_installed" \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: CMake Build
         run: |
-          cmake --build build --config Release
-          cmake --build build --config Debug
-
-      - name: CMake Install
-        run: |
-          cmake --install build --config Release --prefix install/release
-          cmake --install build --config Debug --prefix install/debug
+          cmake --build build/release --config Release --target install
+          cmake --build build/debug --config Debug --target install
 
       - name: Upload Release
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,10 +89,31 @@ jobs:
           cmake --build build/release --config Release --target install
           cmake --build build/debug --config Debug --target install
 
-      - name: Upload Release
+      - name: Tar Artifacts (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          tar -cvf AprilTagTrackers-Linux.tar install/release/
+          tar -cvf AprilTagTrackers-Debug-Linux.tar install/debug/
+
+      - name: Upload Release (Linux)
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v3
         with:
-          name: AprilTagTrackers-${{ runner.os }}
+          name: AprilTagTrackers-Linux
+          path: AprilTagTrackers-Linux.tar
+
+      - name: Upload Debug (Linux)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: AprilTagTrackers-Debug-Linux
+          path: AprilTagTrackers-Debug-Linux.tar
+
+      - name: Upload Release (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: AprilTagTrackers-Windows
           path: |
             install/release
             !install/release/**.pdb
@@ -102,15 +123,14 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: AprilTagTrackers.pdb
-          path: |
-            install/release/**.pdb
+          path: install/release/**.pdb
 
-      - name: Upload Debug
+      - name: Upload Debug (Windows)
+        if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v3
         with:
-          name: AprilTagTrackers-Debug-${{ runner.os }}
-          path: |
-            install/debug
+          name: AprilTagTrackers-Debug-Windows
+          path: install/debug
 
       - name: Upload Logs
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,6 @@ on:
     paths-ignore: ["**.md"]
 
 env:
-  BUILD_TYPE: Release
-  BINARY_DIR: build
-  INSTALL_DIR: install
   # read only permission if pull request
   VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,read${{ github.event_name == 'push' && 'write' || '' }}"
 
@@ -34,18 +31,13 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v3
 
-      - name: Install Linux Dependencies
-        if: ${{ matrix.os == 'ubuntu-latest'}}
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y build-essential tar curl zip unzip pkg-config autoconf libudev-dev freeglut3-dev libgtk-3-dev libsecret-1-dev libgcrypt20-dev libsystemd-dev nasm ffmpeg libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-doc gstreamer1.0-tools gstreamer1.0-x gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 gstreamer1.0-qt5 gstreamer1.0-pulseaudio
-
-      - name: Setup vcpkg (Windows)
-        if: matrix.os == 'windows-latest'
-        shell: cmd
-        run: |
-          git clone --depth 1 https://github.com/microsoft/vcpkg
-          ./vcpkg/bootstrap-vcpkg.bat
+      - name: Install Dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: >
+          sudo apt-get update -y && sudo apt-get install -y
+          build-essential tar curl zip unzip pkg-config autoconf ninja-build
+          libudev-dev freeglut3-dev libgtk-3-dev libsecret-1-dev libgcrypt20-dev libsystemd-dev nasm
+          libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-doc gstreamer1.0-tools gstreamer1.0-x gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 gstreamer1.0-qt5 gstreamer1.0-pulseaudio
 
       - name: Setup vcpkg (Linux)
         if: matrix.os == 'ubuntu-latest'
@@ -53,6 +45,13 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/microsoft/vcpkg
           ./vcpkg/bootstrap-vcpkg.sh
+
+      - name: Setup vcpkg (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: |
+          git clone --depth 1 https://github.com/microsoft/vcpkg
+          ./vcpkg/bootstrap-vcpkg.bat
 
       - name: Setup NuGet Credentials
         shell: bash
@@ -64,33 +63,57 @@ jobs:
             -source "${NUGET_URL}" -storepasswordincleartext -name "GitHub" -username "${NUGET_OWNER}" -password "${{ secrets.GITHUB_TOKEN }}"
           ${{ matrix.mono }} "${NUGET_EXE}" setapikey "${{ secrets.GITHUB_TOKEN }}" -source "${NUGET_URL}"
 
+      - name: Developer Command Prompt (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: CMake Configure
-        run: >-
-          cmake -B ${{ env.BINARY_DIR }}
-          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
-          -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }}
-          -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+        run: >
+          cmake -B build -G Ninja Multi-Config
+          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_CMAKE_TOOLCHAIN }}
 
       - name: CMake Build
-        run: cmake --build ${{ env.BINARY_DIR }} --config ${{ env.BUILD_TYPE }} --target install
+        run: |
+          cmake --build build --config Release
+          cmake --build build --config Debug
 
-      - name: Upload Build
+      - name: CMake Install
+        run: |
+          cmake --install build --config Release --prefix install/release
+          cmake --install build --config Debug --prefix install/debug
+
+      - name: Upload Release
         uses: actions/upload-artifact@v3
         with:
           name: AprilTagTrackers-${{ runner.os }}
           path: |
-            ${{ env.INSTALL_DIR }}/
+            install/release
+            !install/release/**.pdb
 
-      - name: Upload CMake Logs
+      - name: Upload Release PDB (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: AprilTagTrackers.pdb
+          path: |
+            install/release/**.pdb
+
+      - name: Upload Debug
+        uses: actions/upload-artifact@v3
+        with:
+          name: AprilTagTrackers-Debug-${{ runner.os }}
+          path: |
+            install/debug
+
+      - name: Upload Logs
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: CMakeLogs-${{ runner.os }}
+          name: Logs-${{ runner.os }}
           path: |
-            ${{ env.BINARY_DIR }}/**/CMakeCache.txt
-            ${{ env.BINARY_DIR }}/**/CMakeOutput.log
-            ${{ env.BINARY_DIR }}/**/CMakeError.log
-            vcpkg/buildtrees/**/*.log
+            build/**/CMakeCache.txt
+            build/**.log
+            vcpkg/buildtrees/**.log
 
   send_discord_nightly_webhook:
     name: Send Discord Nightly Webhook


### PR DESCRIPTION
* Uses ninja to build on windows and ubuntu for moderate speedup.
* Separates the .pdb from windows release to its own artifact.
* Adds more logs
* tars the linux uploads to maintain permissions.
