### PR TITLE
Lock vcpkg version to commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,14 +43,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
-          git clone --depth 1 https://github.com/microsoft/vcpkg
+          git clone --filter=tree:0 https://github.com/microsoft/vcpkg
           ./vcpkg/bootstrap-vcpkg.sh
 
       - name: Setup vcpkg (Windows)
         if: matrix.os == 'windows-latest'
         shell: cmd
         run: |
-          git clone --depth 1 https://github.com/microsoft/vcpkg
+          git clone --filter=tree:0 https://github.com/microsoft/vcpkg
           ./vcpkg/bootstrap-vcpkg.bat
 
       - name: Setup NuGet Credentials

--- a/CMake/helpers.cmake
+++ b/CMake/helpers.cmake
@@ -32,20 +32,20 @@ function(att_bootstrap_vcpkg)
         set(vcpkg_bootstrap_cmd "${VCPKG_ROOT}/bootstrap-vcpkg.sh")
     endif()
 
-    if (NOT EXISTS vcpkg_bootstrap_cmd)
+    if (NOT EXISTS "${vcpkg_bootstrap_cmd}")
         find_program(GIT_CMD git REQUIRED)
         execute_process(COMMAND "${GIT_CMD}" clone --filter=tree:0 "https://github.com/microsoft/vcpkg.git" "${VCPKG_ROOT}")
 
-        if (NOT EXISTS vcpkg_bootstrap_cmd)
+        if (NOT EXISTS "${vcpkg_bootstrap_cmd}")
             message(FATAL_ERROR "failed to clone vcpkg")
         endif()
     endif()
 
-    if (NOT EXISTS vcpkg_cmd)
+    if (NOT EXISTS "${vcpkg_cmd}")
         execute_process(COMMAND "${vcpkg_bootstrap_cmd}" -disableMetrics
             WORKING_DIRECTORY "${VCPKG_ROOT}")
 
-        if (NOT EXISTS vcpkg_cmd)
+        if (NOT EXISTS "${vcpkg_cmd}")
             message(FATAL_ERROR "failed to bootstrap vcpkg")
         endif()
     endif()

--- a/CMake/helpers.cmake
+++ b/CMake/helpers.cmake
@@ -21,23 +21,8 @@ function(att_bootstrap_vcpkg)
         set(vcpkg_default_root "${CMAKE_CURRENT_SOURCE_DIR}/.vcpkg")
     endif()
 
-    # not first run and vcpkg_root has not changed since first run
-    if (DEFINED VCPKG_ROOT AND VCPKG_ROOT STREQUAL vcpkg_default_root)
-        message(STATUS "vcpkg root: ${VCPKG_ROOT}")
-        return()
-    endif()
-
     set(VCPKG_ROOT "${vcpkg_default_root}" CACHE PATH "vcpkg root directory")
     message(STATUS "vcpkg root: ${VCPKG_ROOT}")
-
-    if (NOT EXISTS "${VCPKG_ROOT}/.vcpkg-root")
-        find_program(GIT_CMD git REQUIRED)
-        execute_process(COMMAND "${GIT_CMD}" clone --filter=tree:0 "https://github.com/Microsoft/vcpkg.git" "${VCPKG_ROOT}")
-
-        if (NOT EXISTS "${VCPKG_ROOT}/.vcpkg-root")
-            message(FATAL_ERROR "failed to clone vcpkg")
-        endif()
-    endif()
 
     if (WIN32)
         set(vcpkg_cmd "${VCPKG_ROOT}/${vcpkg_cmd}")
@@ -47,11 +32,20 @@ function(att_bootstrap_vcpkg)
         set(vcpkg_bootstrap_cmd "${VCPKG_ROOT}/bootstrap-vcpkg.sh")
     endif()
 
-    if (NOT EXISTS "${vcpkg_cmd}")
+    if (NOT EXISTS vcpkg_bootstrap_cmd)
+        find_program(GIT_CMD git REQUIRED)
+        execute_process(COMMAND "${GIT_CMD}" clone --filter=tree:0 "https://github.com/microsoft/vcpkg.git" "${VCPKG_ROOT}")
+
+        if (NOT EXISTS vcpkg_bootstrap_cmd)
+            message(FATAL_ERROR "failed to clone vcpkg")
+        endif()
+    endif()
+
+    if (NOT EXISTS vcpkg_cmd)
         execute_process(COMMAND "${vcpkg_bootstrap_cmd}" -disableMetrics
             WORKING_DIRECTORY "${VCPKG_ROOT}")
 
-        if (NOT EXISTS "${vcpkg_cmd}")
+        if (NOT EXISTS vcpkg_cmd)
             message(FATAL_ERROR "failed to bootstrap vcpkg")
         endif()
     endif()

--- a/CMake/helpers.cmake
+++ b/CMake/helpers.cmake
@@ -32,7 +32,7 @@ function(att_bootstrap_vcpkg)
 
     if (NOT EXISTS "${VCPKG_ROOT}/.vcpkg-root")
         find_program(GIT_CMD git REQUIRED)
-        execute_process(COMMAND "${GIT_CMD}" clone --depth 1 "https://github.com/Microsoft/vcpkg.git" "${VCPKG_ROOT}")
+        execute_process(COMMAND "${GIT_CMD}" clone --filter=tree:0 "https://github.com/Microsoft/vcpkg.git" "${VCPKG_ROOT}")
 
         if (NOT EXISTS "${VCPKG_ROOT}/.vcpkg-root")
             message(FATAL_ERROR "failed to clone vcpkg")

--- a/vcpkg-ports/opencv4/portfile.cmake
+++ b/vcpkg-ports/opencv4/portfile.cmake
@@ -398,6 +398,7 @@ vcpkg_cmake_configure(
         -DOPENCV_DLLVERSION=
         -DOPENCV_DEBUG_POSTFIX=d
         -DOPENCV_GENERATE_SETUPVARS=OFF
+        -DOPENCV_GENERATE_PKGCONFIG=ON
         # Do not build docs/examples
         -DBUILD_DOCS=OFF
         -DBUILD_EXAMPLES=OFF

--- a/vcpkg-ports/opencv4/vcpkg.json
+++ b/vcpkg-ports/opencv4/vcpkg.json
@@ -43,6 +43,9 @@
         }
       ]
     },
+    "contrib-aruco": {
+      "description": "aruco from opencv_contrib, don't enable with 'contrib'"
+    },
     "cuda": {
       "description": "CUDA support for opencv",
       "dependencies": [

--- a/vcpkg-ports/opencv4/vcpkg.json
+++ b/vcpkg-ports/opencv4/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "opencv4",
   "version": "4.5.5",
-  "port-version": 5,
+  "port-version": 6,
   "description": "computer vision library",
   "homepage": "https://github.com/opencv/opencv",
   "license": "Apache-2.0",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -26,5 +26,6 @@
         "libusb",
         "apriltag",
         "openvr"
-    ]
+    ],
+    "builtin-baseline": "cef0b3ec767df6e83806899fe9525f6cf8d7bc91"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,8 +7,8 @@
             "name": "opencv4",
             "default-features": false,
             "features": [
-              "contrib",
-              "ffmpeg"
+                "contrib-aruco",
+                "ffmpeg"
             ]
         },
         {


### PR DESCRIPTION
Fixes att_bootstrap_vcpkg to fetch every commit, allowing for setting a specific commit to fetch against.
updates opencv4 port to remove unused deps.