### PR TITLE
remove filter=tree from submodule clone

### DIFF
--- a/CMake/helpers.cmake
+++ b/CMake/helpers.cmake
@@ -257,7 +257,7 @@ function(att_clone_submodule module_dir)
     endif()
     message(STATUS "Cloning submodule '${module_dir}'")
     execute_process(
-        COMMAND "${GIT_CMD}" submodule --quiet update --init --filter=tree:0 --recursive "${abs_module_dir}"
+        COMMAND "${GIT_CMD}" submodule --quiet update --init --recursive "${abs_module_dir}"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
     if (NOT EXISTS "${abs_module_dir}/.git")
         message(FATAL_ERROR "Submodule ${abs_module_dir} failed to clone.")


### PR DESCRIPTION
not supported on earlier git versions, and currently we only clone the BridgeDriver which isnt a large repo.