### PR TITLE
Refactor: combine playspace calibration

### DIFF
--- a/AprilTagTrackers/Tracker.cpp
+++ b/AprilTagTrackers/Tracker.cpp
@@ -1077,7 +1077,7 @@ public:
             cv::Point2d maskCenter;
             if (isValid) // if the pose from steamvr was valid, save the predicted position and rotation
             {
-                if (previewIsVisible) cv::aruco::drawAxis(drawImg, camCalib->cameraMatrix, camCalib->distortionCoeffs, pose.rotation.toRotVec(), math::ToVec(pose.position), 0.10F);
+                if (previewIsVisible) cv::drawFrameAxes(drawImg, camCalib->cameraMatrix, camCalib->distortionCoeffs, pose.rotation.toRotVec(), math::ToVec(pose.position), 0.10F);
 
                 if (!unit.WasVisibleLastFrame()) // if tracker was found in previous frame, we use that position for masking. If not, we use position from driver for masking.
                 {

--- a/AprilTagTrackers/Tracker.hpp
+++ b/AprilTagTrackers/Tracker.hpp
@@ -40,6 +40,8 @@ public:
 
     Pose Transform(const Pose& pose) const
     {
+        return {mTransform * pose.position, mRotation * pose.rotation};
+    }
     Pose InvTransform(const Pose& pose) const
     {
         return {mInvTransform * pose.position, mInvRotation * pose.rotation};

--- a/AprilTagTrackers/Tracker.hpp
+++ b/AprilTagTrackers/Tracker.hpp
@@ -36,12 +36,11 @@ public:
         Set(calib.posOffset, calib.angleOffset, calib.scale);
     }
 
-    void Transform(cv::Point3d& pos, cv::Quatd& rot) const
+    Pose Transform(const Pose& pose) const
     {
-        pos = mTransform * pos;
-        rot = mRotation * rot;
+        return { mTransform * pose.position, mRotation * pose.rotation };
     }
-    void Transform(Pose& pose) const { Transform(pose.position, pose.rotation); }
+    cv::Point3d Transform(const cv::Point3d& pos) const { return mTransform * pos; }
 
     double GetScale() const { return mScale; }
 

--- a/AprilTagTrackers/Tracker.hpp
+++ b/AprilTagTrackers/Tracker.hpp
@@ -33,7 +33,7 @@ public:
         mInvRotation = mRotation.inv();
         mScale = scale;
     }
-    void Set(cfg::ManualCalib::Real calib)
+    void Set(const cfg::ManualCalib::Real& calib)
     {
         Set(calib.posOffset, calib.angleOffset, calib.scale);
     }

--- a/AprilTagTrackers/Tracker.hpp
+++ b/AprilTagTrackers/Tracker.hpp
@@ -62,6 +62,14 @@ public:
         return p;
     }
 
+    Pose GetStationPose() const { return {mTransform.translation(), mRotation}; }
+    Pose GetStationPoseOVR() const
+    {
+        Pose pose = GetStationPose();
+        CoordTransformOVR(pose.position);
+        CoordTransformOVR(pose.rotation);
+        return pose;
+    }
     double GetScale() const { return mScale; }
 
 private:

--- a/AprilTagTrackers/Tracker.hpp
+++ b/AprilTagTrackers/Tracker.hpp
@@ -31,6 +31,10 @@ public:
         mRotation = cv::Quatd::createFromRotMat(rotMat).normalize();
         mScale = scale;
     }
+    void Set(cfg::ManualCalib::Real calib)
+    {
+        Set(calib.posOffset, calib.angleOffset, calib.scale);
+    }
 
     void Transform(cv::Point3d& pos, cv::Quatd& rot) const
     {

--- a/AprilTagTrackers/Tracker.hpp
+++ b/AprilTagTrackers/Tracker.hpp
@@ -48,6 +48,20 @@ public:
     }
     cv::Point3d Transform(const cv::Point3d& pos) const { return mTransform * pos; }
 
+    Pose TransformToOVR(Pose pose) const
+    {
+        CoordTransformOVR(pose.position);
+        CoordTransformOVR(pose.rotation);
+        return Transform(pose);
+    }
+    Pose InvTransformFromOVR(const Pose& pose) const
+    {
+        Pose p = InvTransform(pose);
+        CoordTransformOVR(p.position);
+        CoordTransformOVR(p.rotation);
+        return p;
+    }
+
     double GetScale() const { return mScale; }
 
 private:

--- a/AprilTagTrackers/Tracker.hpp
+++ b/AprilTagTrackers/Tracker.hpp
@@ -169,14 +169,7 @@ private:
         gui->ShowPopup(msg, PopupStyle::Error);
     }
 
-    /// Sets the wtransform, wrotation, and wscale
-    // TODO: rename uses of world transform and manual calib to playspace calibration
-    void SetWorldTransform(const cfg::ManualCalib::Real& calib);
-    /// Calibration transformation
-    cv::Affine3d wtransform;
-    /// wtransform rotation part as a quaternion
-    cv::Quatd wrotation;
-    double wscale = 1;
+    PlayspaceCalib mPlayspace;
 
     tracker::VideoCapture mCapture;
 

--- a/AprilTagTrackers/Tracker.hpp
+++ b/AprilTagTrackers/Tracker.hpp
@@ -29,6 +29,8 @@ public:
         cv::Matx33d rotMat = EulerAnglesToRotationMatrix(angleOffset);
         mTransform = cv::Affine3d(rotMat, posOffset);
         mRotation = cv::Quatd::createFromRotMat(rotMat).normalize();
+        mInvTransform = mTransform.inv();
+        mInvRotation = mRotation.inv();
         mScale = scale;
     }
     void Set(cfg::ManualCalib::Real calib)
@@ -38,7 +40,9 @@ public:
 
     Pose Transform(const Pose& pose) const
     {
-        return { mTransform * pose.position, mRotation * pose.rotation };
+    Pose InvTransform(const Pose& pose) const
+    {
+        return {mInvTransform * pose.position, mInvRotation * pose.rotation};
     }
     cv::Point3d Transform(const cv::Point3d& pos) const { return mTransform * pos; }
 
@@ -47,6 +51,8 @@ public:
 private:
     cv::Affine3d mTransform{};
     cv::Quatd mRotation{};
+    cv::Affine3d mInvTransform{};
+    cv::Quatd mInvRotation{};
     double mScale = 0;
 };
 


### PR DESCRIPTION
Depends #112
Its still called manualCalib in the config, but the precomputed transformations are now called PlayspaceCalib.