### PR TITLE
Fix cmake file not adding header files to sources

### DIFF
--- a/AprilTagTrackers/CMakeLists.txt
+++ b/AprilTagTrackers/CMakeLists.txt
@@ -156,6 +156,9 @@ file(GLOB_RECURSE HEADER_GROUP RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" *.hpp *.h)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" PREFIX "Source Files" FILES ${SOURCE_GROUP})
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" PREFIX "Header Files" FILES ${HEADER_GROUP})
 
+#add headers or they may not appear in IDE
+target_sources(AprilTagTrackers PRIVATE ${HEADER_GROUP})
+
 if (ENABLE_TESTING)
     add_subdirectory("test")
 endif()


### PR DESCRIPTION
Using source_group to add header files to show up in IDE seems to not be enough.

This PR adds header files to project using target_sources to ensure the header files can be seen in IDE file explorer.