### PR TITLE
Windows build guide, optimization flags and verbose exposure script

### DIFF
--- a/AprilTagTrackers/CMakeLists.txt
+++ b/AprilTagTrackers/CMakeLists.txt
@@ -127,6 +127,11 @@ if(ATT_ENABLE_ASAN)
     att_target_enable_asan(AprilTagTrackers)
 endif()
 
+# Build with MSVC-specific code optimization flags for release.
+if(ATT_ENABLE_MSVC_OPTIMIZATION_FLAGS)
+    att_target_msvc_release_flags(AprilTagTrackers)
+endif()
+
 # Precompiled std and library headers
 # target_precompile_headers(AprilTagTrackers PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/pch.hpp")
 

--- a/CMake/helpers.cmake
+++ b/CMake/helpers.cmake
@@ -32,14 +32,18 @@ function(att_bootstrap_vcpkg)
         set(vcpkg_bootstrap_cmd "${VCPKG_ROOT}/bootstrap-vcpkg.sh")
     endif()
 
-    if (NOT EXISTS "${vcpkg_bootstrap_cmd}")
-        find_program(GIT_CMD git REQUIRED)
-        execute_process(COMMAND "${GIT_CMD}" clone --filter=tree:0 "https://github.com/microsoft/vcpkg.git" "${VCPKG_ROOT}")
+    ## If Vcpkg is already installed and set in Windows Environment, stick with it and don't enforce in-house vcpkg.
+    ## Removes the possibility of vcpkg git errors, it is faster and compiles successfully. (VS 2022 17.7.5) 
+    if(NOT "${vcpkg_default_root}" STREQUAL "$ENV{VCPKG_ROOT}" AND WIN32)
+       if (NOT EXISTS "${vcpkg_bootstrap_cmd}")
+           find_program(GIT_CMD git REQUIRED)
+           execute_process(COMMAND "${GIT_CMD}" clone --filter=tree:0 "https://github.com/microsoft/vcpkg.git" "${VCPKG_ROOT}")
 
-        if (NOT EXISTS "${vcpkg_bootstrap_cmd}")
-            message(FATAL_ERROR "failed to clone vcpkg")
+           if (NOT EXISTS "${vcpkg_bootstrap_cmd}")
+               message(FATAL_ERROR "failed to clone vcpkg")
+           endif()
         endif()
-    endif()
+	endif()
 
     if (NOT EXISTS "${vcpkg_cmd}")
         execute_process(COMMAND "${vcpkg_bootstrap_cmd}" -disableMetrics

--- a/CMake/helpers.cmake
+++ b/CMake/helpers.cmake
@@ -34,7 +34,7 @@ function(att_bootstrap_vcpkg)
 
     ## If Vcpkg is already installed and set in Windows Environment, stick with it and don't enforce in-house vcpkg.
     ## Removes the possibility of vcpkg git errors, it is faster and compiles successfully. (VS 2022 17.7.5) 
-    if(NOT "${vcpkg_default_root}" STREQUAL "$ENV{VCPKG_ROOT}" AND WIN32)
+    if(NOT (WIN32 AND "${vcpkg_default_root}" STREQUAL "$ENV{VCPKG_ROOT}"))
        if (NOT EXISTS "${vcpkg_bootstrap_cmd}")
            find_program(GIT_CMD git REQUIRED)
            execute_process(COMMAND "${GIT_CMD}" clone --filter=tree:0 "https://github.com/microsoft/vcpkg.git" "${VCPKG_ROOT}")
@@ -43,7 +43,7 @@ function(att_bootstrap_vcpkg)
                message(FATAL_ERROR "failed to clone vcpkg")
            endif()
         endif()
-	endif()
+    endif()
 
     if (NOT EXISTS "${vcpkg_cmd}")
         execute_process(COMMAND "${vcpkg_bootstrap_cmd}" -disableMetrics

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option(ATT_ENABLE_DEBUG_DRIVER "Build and install a debug/testing driver" OFF)
 option(ATT_DEBUG "Developer mode. Enable custom assert, debug logging, and debugger support. Can be used in release build." OFF)
 option(ATT_ENABLE_ANALYZER "Enable compiler static analyzers with ATT_DEBUG. CPU intensive." OFF)
 option(ATT_ENABLE_ASAN "Build with address sanitizer" OFF)
+option(ATT_ENABLE_MSVC_OPTIMIZATION_FLAGS "Additional MSVC compiler optimization flags for release build." ON)
 set(ATT_LOG_LEVEL "1" CACHE STRING "0 - Silent, 1 - Info, 2 - Debug")
 option(ATT_TEST_ENABLE_ASAN "Build tests with address sanitizer" ON)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev lib
 
 
 ### Windows prerequisites
-Open in Visual Studio, or use the Visual Studio Command Prompt.
+Open in Visual Studio 17.8 Preview 2 or newer[(Includes a fix)](https://github.com/microsoft/vcpkg/issues/31565#issuecomment-1723267213), and use the Visual Studio Command Prompt.
 
 
 ### Clone and build
@@ -70,7 +70,7 @@ cmake -B build
 cmake --build build --config Release --target install
 ```
 
-That should be it! In case you try it before a more detailed guide is up, we are always there to help on the discord server! (link above)
+That should be it! [A more detailed guide is up](https://github.com/ju1ce/April-Tag-VR-FullBody-Tracker/blob/master/WindowsBuild_Simple.md), and we are always there to help on the (discord server)[https://discord.gg/g2ctkXB4bb]!
 
 ### Troubleshooting
 

--- a/WindowsBuild_Simple.md
+++ b/WindowsBuild_Simple.md
@@ -1,0 +1,69 @@
+Compile steps for Windows:
+
+__1-__ Download and install Visual Studio 2022 17.8 Preview 2 or newer [(This includes a Msys fix we need)](https://github.com/microsoft/vcpkg/issues/31565#issuecomment-1723267213), check enable building for C/C++ desktop applications during installation.
+
+__2-__ Copy paste this into the address bar of your browser, to clone and open the master branch in VS2022. When it finishes, confirm Retargeting as shown.
+```
+git-client://clone?repo=https%3A%2F%2Fgithub.com%2Fju1ce%2FApril-Tag-VR-FullBody-Tracker
+```
+
+![image](https://github.com/Skyrion9/April-Tag-VR-FullBody-Tracker/assets/74653117/59955543-1596-4e4a-b804-5a1c8000b3cc)
+
+
+
+
+We'll switch to Folder view so VS will recognize the project properly. Click on the leftmost icon in Solution Explorer, and click on Folder View.
+
+![image](https://github.com/Skyrion9/April-Tag-VR-FullBody-Tracker/assets/74653117/6c675ca3-c60d-46e8-9c72-ffb421c78895)
+
+
+
+
+
+
+__4-__ Let it rip. Hopefully it'll finish without errors. When you get output : ```[CMake] -- Running vcpkg install - done```, proceed to next step. If you got CXX compiler errors after that line ignore those. VS is trying to use an incorrect install build configuration (of its own making). Remember you can CTRL+F and search for the output mentioned here, as the output window can get cluttered. What's important is vcpkg install finishing.
+
+If you got ```1> [CMake] CMake Error at scripts/cmake/vcpkg_acquire_msys.cmake:150 (file):```
+
+You didn't install the preview version, did you? Go back and do it you lazy sloth you.
+
+__5-__ In VS, hit View > Terminal and paste the following code into the Developer PowerShell:
+```
+cmake -B build
+cmake --build build --config Release --target install
+```
+
+You can find the program in "Install" folder if it compiled successfully.
+
+## FAQ (Probably?)
+There are still ongoing fixes from Microsoft's side, which you won't find out about until you run into an error. Those have been pending for months. This is why Preview version is recommended as it has a fix we need, when the stable version is updated to 17.8 or newer you won't need this.
+
+__1-__ I still can't compile
+
+Either use a precompiled exe from Release, or make sure to follow each step exactly, Without alternating to different IDEs etc. Pay attention to Output window and fix anything missing. It's usually a vcpkg bug. In case of missing directory errors, double check your Windows Environment path and add any missing paths that show up in the output. Remember to restart VS and regenerate cache so path changes are recognized.
+
+Keep in mind, if you get errors at step 4 you can still try step 5. We only need VS to prepare the dependencies for us. It might fail to build, but we bypass this by using the powershell terminal command. You still need to make sure it succeeds in installing vcpkg in the very least ```[CMake] -- Running vcpkg install - done```
+
+__1.1-__ If you've an error related to Powershell, I recommend installing Powershell 7. Add it to your User ENV path (Regardless of installation ENV setting. As it adds to System path, but I had to manually add it to User ENV. Alternatively, running VS as admin might fix this and break some other things.) Sometimes VS installer clears up your path.
+
+Same path addition should fix the default Powershell if you want to skip PS7.
+
+__1.2-__ [There's a bug where Vcpkg can't install/find Msys](https://github.com/microsoft/vcpkg/issues/31565#issuecomment-1723267213). If your VS 2022 version is older than 17.8, you'll have this error. It is however fixed in 17.8 Preview 2 or newer. 
+
+__2-__ I've an error, how can I get help?
+
+Double check your steps and make sure you've read through all of this. Reminder Visual Studio installer sometimes resets PATH environment variable when installing in an attempt to tidy it up. If CMake fails to recognize something you've installed, this is probably the reason. You must add anything missing to Path manually.
+
+Otherwise try [ApriltagVR's discord](https://discord.gg/g2ctkXB4bb). You'll get better help there. 
+
+__3-__ Wow you've read this far? Here's a little reward for you.
+```
+@@echo off
+start "" "%~dp0AprilTagTrackers.exe"
+call "%~dp0\utilities\set_exposure.bat"
+exit
+```
+Optional batch script to start Apriltag and apply IP Webcam settings simultaneously, unnecessary if you don't use IP Webcam.
+Create a notepad file, copy paste the above code in, rename it to "APTGVR_IPCam.bat" file and move it next to AprilTagTrackers.exe and run it as Administrator (Make a shortcut and in properties > shortcut > advanced enable it)
+
+It'll automatically apply your parameters configured within utilities\set_exposure.bat and launch APTVR, so make sure to update that batch file with your IP Camera parameters first!

--- a/utilities/set_exposure.bat
+++ b/utilities/set_exposure.bat
@@ -1,16 +1,31 @@
+::Set your IP webcam ip bellow. Do not append http:// or /video here!
 
-::set your IP webcam ip bellow. Do not append http:// or /video here!
+set addr=192.168.1.102:8090
 
-set addr=192.168.1.102:8080
-
-::set the wanted exposure. Set this to as low as you can while the image is still bright enough.
-::in general, 10000 is enough for regular usage, while 5000 will allow extremely fast movement.
+::Set the wanted exposure. Set this to as low as you can while the image is still bright enough.
+::In general, 10000 is enough for regular usage, while 5000 will allow extremely fast movement.
 
 set exposure=7000
 
+::Set connection timeout. If you're bothered by CMD file staying open for long even when you're not using an IP webcam, reduce this. Default is 4 seconds.
 
-curl %addr%/settings/manual_sensor?set=on
-curl %addr%/settings/iso?set=1000
-curl %addr%/settings/exposure_ns?set=%exposure%000
-curl %addr%/settings/focusmode?set=off
-curl %addr%/settings/focus_distance?set=1
+set connectionTimeOut=4
+Echo "Looking for IP Webcam... Timeout is %connectionTimeOut% seconds"
+
+::Check if the IP webcam is alive.
+curl -s -I --connect-timeout %connectionTimeOut% %addr% >nul
+
+::Apply values if IP webcam was found. Otherwise exit immediately so CMD doesn't wait on curl to finish, obstructing view.
+if errorlevel 1 (
+	Echo "IP Webcam not found, exiting."
+	timeout /T 2
+	exit
+	) else ( 
+		curl %addr%/settings/manual_sensor?set=on
+		::Change ISO here if your camera supports something higher without getting noisy. It'll help you get a lower exposure value by increasing light sensitivity. Common alternatives are 1600, 3200 etc.
+
+		curl %addr%/settings/iso?set=1000
+		curl %addr%/settings/exposure_ns?set=%exposure%000
+		curl %addr%/settings/focusmode?set=off
+		curl %addr%/settings/focus_distance?set=1
+		)


### PR DESCRIPTION
I had many issues compiling for Windows. I used existing vcpkg from windows ENV to fix/work around the first error. But you need VS 2022 17.8 Preview 2 or later to avoid msys error when building master. I wrote a guide to compile on Windows.

Using non-destructive optimization flags with a bias towards runtime speed over size. In my limited profiling there's no performance degradation, and kernel spends slightly more CPU time (~1%) on apriltag functions within same time frame. Within margin of error, this means either the CPU is being utilized better, or less efficiently. Minor filesize and memory footprint increase due to more aggressive function inlining and double-alignment in memory among other things. Note that MSVC usually doesn't just apply the flags but checks if they would be beneficial first.

You can easily override them by using your own flags from terminal, they are safe fast defaults so to speak. There's more to do on the Linux side of things there but O2 is a good start. There could be potential gains from using (AVX/2/512), Maybe an AVX build could be released along with the normal SSE from here on out since VRChat requires AVX so most of the users already have it. 

I've also updated the exposure script to be more verbose. It was annoying not knowing if it changed anything without checking my phone, The script tells you if IP is not found, and doesn't wait on Curl's long timeout.